### PR TITLE
[oneshot] Provide SessionBus address for user scripts. Fixes JB#54318

### DIFF
--- a/services/oneshot-user-late-privileged@.service
+++ b/services/oneshot-user-late-privileged@.service
@@ -13,5 +13,6 @@ RequiresMountsFor=/home
 Type=oneshot
 User=%i
 Group=privileged
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%i/dbus/user_bus_socket
 RemainAfterExit=yes
 ExecStart=/usr/bin/oneshot --late

--- a/services/oneshot-user-privileged@.service
+++ b/services/oneshot-user-privileged@.service
@@ -13,5 +13,6 @@ RequiresMountsFor=/home
 Type=oneshot
 User=%i
 Group=privileged
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%i/dbus/user_bus_socket
 RemainAfterExit=yes
 ExecStart=/usr/bin/oneshot


### PR DESCRIPTION
Oneshot user scripts are executed in system service context with uid
and gid set to appropriate values. However, as DBUS_SESSION_BUS_ADDRESS
environment value is not set, scripts that need to perform actions on
D-Bus SessionBus will fail.

Setup appropriate for user DBUS_SESSION_BUS_ADDRESS environment value.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>